### PR TITLE
Include mods. to build w/ GCC

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <intrin.h>
+#include <immintrin.h>
 #include <cstring>
 #include <cassert>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 #define NDEBUG
 
-#include "UCI.h"
+#include "uci.h"
 
 using namespace Clovis;
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1,5 +1,5 @@
 #include "position.h"
-#include "UCI.h"
+#include "uci.h"
 
 namespace Clovis {
 

--- a/src/search.h
+++ b/src/search.h
@@ -2,7 +2,7 @@
 
 #include <math.h>
 
-#include "UCI.h"
+#include "uci.h"
 #include "position.h"
 #include "evaluate.h"
 #include "movelist.h"


### PR DESCRIPTION
Should `immintrin.h` not be sufficient with MSVC, then an `#ifdef` statement to choose between `intrin.h` and `immintrin.h` should work. Other change was having `uci.h` match the case of its filename (headers can be case-sensitive).