### PR TITLE
Remove explicit template instantiation in headers

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -283,8 +283,4 @@ namespace clovis::eval {
 
 	template<bool TRACE> int evaluate(const Position& pos);
 
-	// explicit template instantiations
-	template int evaluate<true>(const Position& pos);
-	template int evaluate<false>(const Position& pos);
-
 } // namespace clovis::eval


### PR DESCRIPTION
Explicit template instantiations expect a definition, which is only found outsize of the `evaluate.h` header file, thus causing a compile error.

(Also, the unused TT functions are warnings made errors by `-Werror`, although I expect those are intended to be used at some point).